### PR TITLE
github-calendar 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-calendar",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Embed your GitHub contributions calendar anywhere.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-calendar",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Embed your GitHub contributions calendar anywhere.",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Bringing back the global stats. By default, we will display the global stats like before, but there is an option to disable them: `global_stats:false`.

Recently, GitHub removed the global stats from the site, so now we are computing them using the parser I wrote few months ago: https://github.com/IonicaBizau/github-calendar-parser

:tada:
