### PR TITLE
github-calendar 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Have an idea? Found a bug? See [how to contribute][contributing].
 
  - [`github-profile-languages`](https://github.com/IonicaBizau/github-profile-languages)—Create a nice pie chart with the user's programming languages from their GitHub profile.
  - [`github-org-members.js`](https://github.com/IonicaBizau/github-org-members.js)—A JavaScript library for fetching and rendering in HTML the members of a GitHub organization.
- - [`github-contributions`](https://github.com/kubosho/node-github-contributions)—GitHub Contributions API implementation for Node.js (unofficial).
+ - [`gh-contributions`](https://github.com/IonicaBizau/github-contributions)—A tool that generates a repository which being pushed into your GitHub account creates a nice contributions calendar.
  - [`github-emojify`](https://github.com/IonicaBizau/github-emojifiy#readme)—Emojify your GitHub repository descriptions.
  - [`github-stats`](https://github.com/IonicaBizau/github-stats)—Visualize stats about GitHub users and projects in your terminal.
  - [`github-labeller`](https://github.com/IonicaBizau/github-labeller#readme)—Automagically create issue labels in your GitHub projects.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-calendar",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Embed your GitHub contributions calendar anywhere.",
   "main": "lib/index.js",
   "directories": {
@@ -86,7 +86,7 @@
       "ul": [
         "github-profile-languages",
         "github-org-members.js",
-        "github-contributions",
+        "gh-contributions",
         "github-emojify",
         "github-stats",
         "github-labeller",


### PR DESCRIPTION
Fixed typo in the related package names
