### PR TITLE
Use faster loading GitHub contributions URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ module.exports = function GitHubCalendar (container, username, options) {
         return "https://urlreq.appspot.com/req?method=GET&url=" + url;
     };
 
-    let fetchCalendar = () => fetch(options.proxy("https://github.com/" + username)).then(response => {
+    let fetchCalendar = () => fetch(options.proxy("https://github.com/users/" + username + "/contributions")).then(response => {
         return response.text()
     }).then(body => {
         let div = document.createElement("div");


### PR DESCRIPTION
Performance report for current URL: https://gtmetrix.com/reports/github.com/sADIwSjD
Performance report for new URL: https://gtmetrix.com/reports/github.com/AgrJ8gwG

20 kb vs 382 kb download. All selectors are compatible from my checks.