### PR TITLE
Add tooltip with contribution count and date on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Brings the contributions calendar from GitHub (provided username) into your page
      The default is using @Bloggify's APIs.
    - `global_stats` (Boolean): If `false`, the global stats (total, longest and current streaks) will not be calculated and displayed. By default this is enabled.
    - `responsive` (Boolean): If `true`, the graph is changed to scale with the container. Custom CSS should be applied to the element to scale it appropriately. By default this is disabled.
+   - `tooltips` (Boolean): If `true`, tooltips will be shown when hovered over calendar days. By default this is disabled.
    - `cache` (Number) The cache time in seconds.
 
 #### Return

--- a/dist/github-calendar-responsive.css
+++ b/dist/github-calendar-responsive.css
@@ -123,3 +123,35 @@ h2.f4.text-normal.mb-3 {
 #user-activity-overview{
     display:none;
 }
+
+.day-tooltip {
+    white-space: nowrap;
+    position: absolute;
+    z-index: 99999;
+    padding: 10px;
+    font-size: 12px;
+    color: #959da5;
+    text-align: center;
+    background: rgba(0,0,0,.85);
+    border-radius: 3px;
+    display: none;
+    pointer-events: none;
+}
+.day-tooltip strong {
+    color: #dfe2e5;
+}
+.day-tooltip.is-visible {
+    display: block;
+}
+.day-tooltip:after {
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    width: 5px;
+    height: 5px;
+    box-sizing: border-box;
+    margin: 0 0 0 -5px;
+    content: " ";
+    border: 5px solid transparent;
+    border-top-color: rgba(0,0,0,.85)
+}

--- a/dist/github-calendar.css
+++ b/dist/github-calendar.css
@@ -125,3 +125,35 @@ h2.f4.text-normal.mb-3 {
 #user-activity-overview{
     display:none;
 }
+
+.day-tooltip {
+    white-space: nowrap;
+    position: absolute;
+    z-index: 99999;
+    padding: 10px;
+    font-size: 12px;
+    color: #959da5;
+    text-align: center;
+    background: rgba(0,0,0,.85);
+    border-radius: 3px;
+    display: none;
+    pointer-events: none;
+}
+.day-tooltip strong {
+    color: #dfe2e5;
+}
+.day-tooltip.is-visible {
+    display: block;
+}
+.day-tooltip:after {
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    width: 5px;
+    height: 5px;
+    box-sizing: border-box;
+    margin: 0 0 0 -5px;
+    content: " ";
+    border: 5px solid transparent;
+    border-top-color: rgba(0,0,0,.85)
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,43 @@ const parse = require("github-calendar-parser")
 const DATE_FORMAT1 = "MMM D, YYYY"
     , DATE_FORMAT2 = "MMMM D"
 
+const MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
 function printDayCount(dayCount) {
     return  `${dayCount} ${(dayCount === 1) ? "day" : "days"}`
+}
+
+function addTooltips(container) {
+    const tooltip = document.createElement("div")
+    tooltip.classList.add("day-tooltip")
+    container.appendChild(tooltip)
+
+    // Add mouse event listener to show & hide tooltip
+    const days = container.querySelectorAll("rect.day")
+    days.forEach(day => {
+        day.addEventListener("mouseenter", (e) => {
+            let contribCount = e.target.getAttribute("data-count")
+            if (contribCount === "0") {
+                contribCount = "No contributions"
+            } else if (contribCount === "1") {
+                contribCount = "1 contribution"
+            } else {
+                contribCount = `${contribCount} contributions`
+            }
+            const date = new Date(e.target.getAttribute("data-date"))
+            const dateText = `${MONTH_NAMES[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`
+            tooltip.innerHTML = `<strong>${contribCount}</strong> on ${dateText}`
+            tooltip.classList.add("is-visible")
+            const size = e.target.getBoundingClientRect()
+                , leftPos = size.left + window.pageXOffset - tooltip.offsetWidth / 2 + size.width / 2
+                , topPos = size.bottom + window.pageYOffset - tooltip.offsetHeight - 2 * size.height
+            tooltip.style.top = `${topPos}px`
+            tooltip.style.left = `${leftPos}px`
+        })
+        day.addEventListener("mouseleave", () => {
+            tooltip.classList.remove("is-visible")
+        })
+    })
 }
 
 /**
@@ -28,6 +63,7 @@ function printDayCount(dayCount) {
  *      The default is using @Bloggify's APIs.
  *    - `global_stats` (Boolean): If `false`, the global stats (total, longest and current streaks) will not be calculated and displayed. By default this is enabled.
  *    - `responsive` (Boolean): If `true`, the graph is changed to scale with the container. Custom CSS should be applied to the element to scale it appropriately. By default this is disabled.
+ *    - `tooltips` (Boolean): If `true`, tooltips will be shown when hovered over calendar days. By default this is disabled.
  *    - `cache` (Number) The cache time in seconds.
  *
  * @return {Promise} A promise returned by the `fetch()` call.
@@ -133,6 +169,11 @@ module.exports = function GitHubCalendar (container, username, options) {
             }
 
             container.innerHTML = cal.innerHTML
+
+            // If options includes tooltips, add tooltips listeners to SVG
+            if (options.tooltips === true) {
+                addTooltips(container)
+            }
         }
     }).catch(e => console.error(e))
 


### PR DESCRIPTION
Implements feature request in #55 

![github-calendar-tooltip](https://user-images.githubusercontent.com/22729516/83051675-f6c0d980-a06b-11ea-8fa4-1223a409965c.gif)

This PR adds tooltips to hover events on individual days in calendar (as we see on actual github contributions).
I have tried to keep most of the style and tooltip implementation similar to that of actual implementation on Github page.

To make sure this doesn't start showing up tooltips without knowing when users update package version, the tooltip feature remains disabled by default.

New boolean option `tooltips` is added to options to allow user to enable tooltips while initiating github-calendar.

README.md is also updated to reflect new option added for tooltips.