### PR TITLE
fix: tooltips display when mouse hover on 'Less More' boxes, it should be hide.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ function addTooltips(container) {
     container.appendChild(tooltip)
 
     // Add mouse event listener to show & hide tooltip
-    const days = container.querySelectorAll("rect.ContributionCalendar-day")
+    const days = container.querySelectorAll(".js-calendar-graph-svg rect.ContributionCalendar-day")
     days.forEach(day => {
         day.addEventListener("mouseenter", (e) => {
             let contribCount = e.target.getAttribute("data-count")


### PR DESCRIPTION
#142 