### PR TITLE
Required fixes per latest changes on the GitHub UI

### DIFF
--- a/dist/github-calendar-responsive.css
+++ b/dist/github-calendar-responsive.css
@@ -6,24 +6,45 @@
   --color-calendar-graph-day-L4-bg: #0a4208;
 }
 
-rect.ContributionCalendar-day[data-level='0'] {
-    fill: var(--color-calendar-graph-day-bg);
+.ContributionCalendar-day[data-level='0'] {
+    background-color: var(--color-calendar-graph-day-bg);
 }
 
-rect.ContributionCalendar-day[data-level='1'] {
-    fill: var(--color-calendar-graph-day-L1-bg);
+.ContributionCalendar-day[data-level='1'] {
+    background-color: var(--color-calendar-graph-day-L1-bg);
 }
 
-rect.ContributionCalendar-day[data-level='2'] {
-    fill: var(--color-calendar-graph-day-L2-bg);
+.ContributionCalendar-day[data-level='2'] {
+    background-color: var(--color-calendar-graph-day-L2-bg);
 }
 
-rect.ContributionCalendar-day[data-level='3'] {
-    fill: var(--color-calendar-graph-day-L3-bg);
+.ContributionCalendar-day[data-level='3'] {
+    background-color: var(--color-calendar-graph-day-L3-bg);
 }
 
-rect.ContributionCalendar-day[data-level='4'] {
-    fill: var(--color-calendar-graph-day-L4-bg);
+.ContributionCalendar-day[data-level='4'] {
+    background-color: var(--color-calendar-graph-day-L4-bg);
+}
+
+table.ContributionCalendar-grid {
+    margin-bottom: 0pt;
+}
+
+table.ContributionCalendar-grid td {
+    padding: 4pt;
+}
+
+table.ContributionCalendar-grid td span.sr-only {
+    display: none;
+}
+
+td.ContributionCalendar-label span[aria-hidden='true'] {
+    font-size: 8pt;
+    left: -1pt;
+}
+
+tool-tip {
+    display: none;
 }
 
 .calendar .width-full > .float-left {
@@ -45,20 +66,28 @@ rect.ContributionCalendar-day[data-level='4'] {
     fill: #aaa;
 }
 
-.contrib-legend {
+div.px-md-5 {
+    height: 2rem;
+}
+
+div.float-right {
     text-align: right;
     padding: 0 14px 10px 0;
     display: inline-block;
     float: right;
 }
 
-.contrib-legend .legend {
+div.float-right div {
     display: inline-block;
     list-style: none;
     margin: 0 5px;
     position: relative;
     bottom: -1px;
     padding: 0;
+}
+
+div.float-right span.sr-only {
+    display: none;
 }
 
 .contrib-legend .legend li {

--- a/dist/github-calendar.css
+++ b/dist/github-calendar.css
@@ -6,24 +6,45 @@
   --color-calendar-graph-day-L4-bg: #0a4208;
 }
 
-rect.ContributionCalendar-day[data-level='0'] {
-    fill: var(--color-calendar-graph-day-bg);
+.ContributionCalendar-day[data-level='0'] {
+    background-color: var(--color-calendar-graph-day-bg);
 }
 
-rect.ContributionCalendar-day[data-level='1'] {
-    fill: var(--color-calendar-graph-day-L1-bg);
+.ContributionCalendar-day[data-level='1'] {
+    background-color: var(--color-calendar-graph-day-L1-bg);
 }
 
-rect.ContributionCalendar-day[data-level='2'] {
-    fill: var(--color-calendar-graph-day-L2-bg);
+.ContributionCalendar-day[data-level='2'] {
+    background-color: var(--color-calendar-graph-day-L2-bg);
 }
 
-rect.ContributionCalendar-day[data-level='3'] {
-    fill: var(--color-calendar-graph-day-L3-bg);
+.ContributionCalendar-day[data-level='3'] {
+    background-color: var(--color-calendar-graph-day-L3-bg);
 }
 
-rect.ContributionCalendar-day[data-level='4'] {
-    fill: var(--color-calendar-graph-day-L4-bg);
+.ContributionCalendar-day[data-level='4'] {
+    background-color: var(--color-calendar-graph-day-L4-bg);
+}
+
+table.ContributionCalendar-grid {
+    margin-bottom: 0pt;
+}
+
+table.ContributionCalendar-grid td {
+    padding: 4pt;
+}
+
+table.ContributionCalendar-grid td span.sr-only {
+    display: none;
+}
+
+td.ContributionCalendar-label span[aria-hidden='true'] {
+    font-size: 8pt;
+    left: -1pt;
+}
+
+tool-tip {
+    display: none;
 }
 
 .calendar .width-full > .float-left {
@@ -46,20 +67,28 @@ rect.ContributionCalendar-day[data-level='4'] {
     fill: #aaa;
 }
 
-.contrib-legend {
+div.px-md-5 {
+    height: 2rem;
+}
+
+div.float-right {
     text-align: right;
     padding: 0 14px 10px 0;
     display: inline-block;
     float: right;
 }
 
-.contrib-legend .legend {
+div.float-right div {
     display: inline-block;
     list-style: none;
     margin: 0 5px;
     position: relative;
     bottom: -1px;
     padding: 0;
+}
+
+div.float-right span.sr-only {
+    display: none;
 }
 
 .contrib-legend .legend li {

--- a/lib/index.js
+++ b/lib/index.js
@@ -127,7 +127,7 @@ module.exports = function GitHubCalendar (container, username, options) {
         } else {
             // If options includes responsive, SVG element has to be manipulated to be made responsive
             if (options.responsive === true) {
-                let svg = cal.querySelector("svg.js-calendar-graph-svg")
+                let svg = cal.querySelector("table.js-calendar-graph-table")
                 // Get the width/height properties and use them to create the viewBox
                 let width = svg.getAttribute("width")
                 let height = svg.getAttribute("height")
@@ -140,7 +140,7 @@ module.exports = function GitHubCalendar (container, username, options) {
             }
 
             if (options.global_stats !== false) {
-                let parsed = parse($("svg", cal).outerHTML)
+                let parsed = parse(cal.innerHTML)
                   , currentStreakInfo = parsed.current_streak
                                       ? `${formatoid(parsed.current_streak_range[0], DATE_FORMAT2)} &ndash; ${formatoid(parsed.current_streak_range[1], DATE_FORMAT2)}`
                                       : parsed.last_contributed


### PR DESCRIPTION
@IonicaBizau, As stated in issue #172, #171, and #169, a few months ago github-calendar.js stopped working.  Per latest changes to Github UI, the contributions calendar now uses a `<table>` element instead of the former `<svg>`.

Such update on the GitHub side requires some changes to:
- the CSS to, to properly style the table cells, footer, etc.
- and the JavaScript code to query for the right element. 

Given the above, https://github.com/IonicaBizau/github-calendar-parser/ apparently also requires a number of changes to be able to extract the information for the global stats, but that will be a different pull request in the corresponding repository.

The changes in this pull request, plus some additional re-styling yield the result below.
![Screenshot from 2024-02-21 22-29-23](https://github.com/Bloggify/github-calendar/assets/36541918/f949d807-38c0-4e47-82b0-b431eea6a74b)

This fixes issues #172, #171, and #169.